### PR TITLE
Fix README demo link and add usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 </p>
 
 ## Preview
-https://
+https://dynhorolf.github.io/DevLinks/
 
 ## 💻 Project
 
@@ -29,6 +29,16 @@ This project was developed with the following technologies:
 - Figma
 
 From your command line:
+
+```bash
+# Clone the repository
+git clone https://github.com/DynhoROLF/DevLinks.git
+
+# Go into the repository
+cd DevLinks
+
+# Open index.html in your browser
+``` 
 
 ---
 


### PR DESCRIPTION
## Summary
- update preview section with GitHub Pages link
- add basic usage instructions after "From your command line:" heading

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f5faf2fd08328a1179db832cb5c12